### PR TITLE
Persoonsvermelding

### DIFF
--- a/shacl/Av.ttl
+++ b/shacl/Av.ttl
@@ -1,4 +1,5 @@
 @prefix av:           </resources/recordtypes/Av#> .
+@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dbpo:         <http://dbpedia.org/ontology/> .
 @prefix dc:           <http://purl.org/dc/terms/> .
@@ -369,7 +370,7 @@ av:DepictedLocation
   sh:property [
       rdfs:label "Huisnummer"@nl ;
       sh:maxCount 1 ;
-      sh:path schema:streetAddress ;
+      sh:path bag:huisnummer ;
       sh:order 3.0 ;
       sh:datatype xsd:string ;
   ] ;

--- a/shacl/Av.ttl
+++ b/shacl/Av.ttl
@@ -1,5 +1,5 @@
 @prefix av:           </resources/recordtypes/Av#> .
-@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix bag:          <http://bag.basisregistraties.overheid.nl/def/bag#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dbpo:         <http://dbpedia.org/ontology/> .
 @prefix dc:           <http://purl.org/dc/terms/> .
@@ -405,7 +405,7 @@ av:Creator
   sh:property [
     rdfs:label "Rol"@nl ;
     # "Connects a Creation Relation to the Role Type that the creator Agent(s) has in the creation process"
-    sh:path schema:schema:roleName  ;
+    sh:path schema:roleName  ;
     sh:maxCount 5 ;
     sh:order 2.0 ;
     dash:editor memorix:VocabularyEditor ;

--- a/shacl/Av.ttl
+++ b/shacl/Av.ttl
@@ -404,7 +404,7 @@ av:Creator
   sh:property [
     rdfs:label "Rol"@nl ;
     # "Connects a Creation Relation to the Role Type that the creator Agent(s) has in the creation process"
-    sh:path rico:creationWithRole ;
+    sh:path schema:schema:roleName  ;
     sh:maxCount 5 ;
     sh:order 2.0 ;
     dash:editor memorix:VocabularyEditor ;

--- a/shacl/Bestanddeel.ttl
+++ b/shacl/Bestanddeel.ttl
@@ -1,4 +1,4 @@
-@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix bag:          <http://bag.basisregistraties.overheid.nl/def/bag#> .
 @prefix bestanddeel:  </resources/recordtypes/Bestanddeel#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dc:           <http://purl.org/dc/terms/> .

--- a/shacl/Bestanddeel.ttl
+++ b/shacl/Bestanddeel.ttl
@@ -1,3 +1,4 @@
+@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
 @prefix bestanddeel:  </resources/recordtypes/Bestanddeel#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dc:           <http://purl.org/dc/terms/> .
@@ -342,7 +343,7 @@ bestanddeel:HistoricalAddress
         rdfs:label "Huisnummer van"@nl ;
         sh:maxCount 1 ;
         # Dit is een noodgreep. Hier bestaat geen goede property voor
-        sh:path schema:minValue ;
+        sh:path bag:huisnummer ;
         sh:order 3.0 ;
         sh:datatype xsd:string ;
     ] ;
@@ -350,7 +351,7 @@ bestanddeel:HistoricalAddress
         rdfs:label "Huisnummer tot"@nl ;
         sh:maxCount 1 ;
         # Dit is een noodgreep. Hier bestaat geen goede property voor
-        sh:path schema:maxValue ;
+        sh:path bag:huisnummer ;
         sh:order 3.0 ;
         sh:datatype xsd:string ;
     ] ;

--- a/shacl/ErfgoedregisterAdres.ttl
+++ b/shacl/ErfgoedregisterAdres.ttl
@@ -1,4 +1,4 @@
-@prefix bag:                  <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix bag:                  <https://bag.basisregistraties.overheid.nl/def/bag#> .
 @prefix erfgoedregisterAdres: </resources/recordtypes/ErfgoedregisterAdres#> .
 @prefix vocabularies:         </resources/vocabularies/> .
 @prefix xsd:                  <http://www.w3.org/2001/XMLSchema#> .

--- a/shacl/ErfgoedregisterAdres.ttl
+++ b/shacl/ErfgoedregisterAdres.ttl
@@ -1,3 +1,4 @@
+@prefix bag:                  <https://bag.basisregistraties.overheid.nl/datamodel#> .
 @prefix erfgoedregisterAdres: </resources/recordtypes/ErfgoedregisterAdres#> .
 @prefix vocabularies:         </resources/vocabularies/> .
 @prefix xsd:                  <http://www.w3.org/2001/XMLSchema#> .
@@ -42,7 +43,7 @@ recordtypes:ErfgoedregisterAdres
   ] ;
   sh:property [
     rdfs:label "Huisnummer"@nl ;
-    sh:path erfgoedregisterAdres:houseNumber ;
+    sh:path bag:huisnummer ;
     memorix:inTitleAt 3.0 ;
     sh:maxCount 1 ;
     sh:order 3.0 ;

--- a/shacl/Image.ttl
+++ b/shacl/Image.ttl
@@ -371,7 +371,7 @@ image:Creator
   ] ;
   sh:property [
     rdfs:label "Rol"@nl ;
-    sh:path rico:creationWithRole ;
+    sh:path schema:roleName ;
     sh:maxCount 5 ;
     sh:order 2.0 ;
     dash:editor memorix:VocabularyEditor ;

--- a/shacl/Image.ttl
+++ b/shacl/Image.ttl
@@ -1,4 +1,4 @@
-@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix bag:          <http://bag.basisregistraties.overheid.nl/def/bag#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dbpo:         <http://dbpedia.org/ontology/> .
 @prefix dc:           <http://purl.org/dc/terms/> .

--- a/shacl/Image.ttl
+++ b/shacl/Image.ttl
@@ -1,3 +1,4 @@
+@prefix bag:          <https://bag.basisregistraties.overheid.nl/datamodel#> .
 @prefix dash:         <http://datashapes.org/dash#> .
 @prefix dbpo:         <http://dbpedia.org/ontology/> .
 @prefix dc:           <http://purl.org/dc/terms/> .
@@ -337,7 +338,7 @@ image:DepictedLocation
   sh:property [
       rdfs:label "Huisnummer"@nl ;
       sh:maxCount 1 ;
-      sh:path schema:streetAddress ;
+      sh:path bag:huisnummer ;
       sh:order 3.0 ;
       sh:datatype xsd:string ;
   ] ;

--- a/shacl/Object.ttl
+++ b/shacl/Object.ttl
@@ -264,7 +264,7 @@ recordtypes:Object
   sh:property [
     rdfs:label "(BAG-)Adres gegevens"@nl ;
     sh:maxCount 999 ;
-    sh:path bag:identifier ;
+    sh:path bag:identificatie ;
     sh:order 21.0 ;
     dash:viewer dash:DetailsEditor ;
     sh:nodeKind sh:BlankNode ;
@@ -299,43 +299,43 @@ object:Dating
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:Dating ;
   sh:property [
-      rdfs:label "Datering (tekst)"@nl ;
-      sh:path rico:expressedDate ;
-      sh:maxCount 1 ;
-      sh:order 1.0 ;
-      sh:datatype xsd:string ;
-      dash:singleLine true ;
-    ] ;
+    rdfs:label "Datering (tekst)"@nl ;
+    sh:path rico:expressedDate ;
+    sh:maxCount 1 ;
+    sh:order 1.0 ;
+    sh:datatype xsd:string ;
+    dash:singleLine true ;
+  ] ;
   sh:property [
-      rdfs:label "Nauwkeurigheid"@nl ;
-      sh:path rico:certainty ;
-      sh:maxCount 1 ;
-      sh:order 1.5 ;
-      sh:datatype xsd:string ;
-      dash:singleLine true ;
-    ] ;
+    rdfs:label "Nauwkeurigheid"@nl ;
+    sh:path rico:certainty ;
+    sh:maxCount 1 ;
+    sh:order 1.5 ;
+    sh:datatype xsd:string ;
+    dash:singleLine true ;
+  ] ;
   sh:property [
-      rdfs:label "Startdatum"@nl ;
-      sh:path rico:hasBeginningDate ;
-      sh:order 2.0 ;
-      sh:datatype xsd:integer ;
-      dash:editor memorix:DateEditor ;
-    ] ;
+    rdfs:label "Startdatum"@nl ;
+    sh:path rico:hasBeginningDate ;
+    sh:order 2.0 ;
+    sh:datatype xsd:integer ;
+    dash:editor memorix:DateEditor ;
+  ] ;
   sh:property [
-      rdfs:label "Einddatum"@nl ;
-      sh:path rico:hasEndDate ;
-      sh:order 3.0 ;
-      sh:datatype xsd:integer ;
-      dash:editor memorix:DateEditor ;
-    ] ;
+    rdfs:label "Einddatum"@nl ;
+    sh:path rico:hasEndDate ;
+    sh:order 3.0 ;
+    sh:datatype xsd:integer ;
+    dash:editor memorix:DateEditor ;
+  ] ;
   sh:property [
-      rdfs:label "Datering betreft/opmerking"@nl ;
-      sh:path rico:descriptiveNote ;
-      sh:maxCount 1 ;
-      sh:order 0.5 ;
-      sh:datatype xsd:string ;
-      dash:editor  dash:TextAreaEditor ;
-    ] ;
+    rdfs:label "Datering betreft/opmerking"@nl ;
+    sh:path rico:descriptiveNote ;
+    sh:maxCount 1 ;
+    sh:order 0.5 ;
+    sh:datatype xsd:string ;
+    dash:editor  dash:TextAreaEditor ;
+  ] ;
 .
 
 object:ZoningPlan
@@ -344,20 +344,20 @@ object:ZoningPlan
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:ZoningPlan ;
   sh:property [
-      rdfs:label "Datum bestemmingsplan"@nl ;
-      sh:path dc:date ;
-      sh:order 2.0 ;
-      sh:group object:procedureDataGroup ;
-      sh:datatype xsd:integer ;
-      dash:editor memorix:DateEditor ;
-    ] ;
+    rdfs:label "Datum bestemmingsplan"@nl ;
+    sh:path dc:date ;
+    sh:order 2.0 ;
+    sh:group object:procedureDataGroup ;
+    sh:datatype xsd:integer ;
+    dash:editor memorix:DateEditor ;
+  ] ;
   sh:property [
-      rdfs:label "Omgevingsplangebied"@nl ;
-      sh:path rico:location ;
-      sh:maxCount 1 ;
-      sh:order 1.0 ;
-      sh:datatype xsd:string ;
-    ] ;
+    rdfs:label "Omgevingsplangebied"@nl ;
+    sh:path rico:location ;
+    sh:maxCount 1 ;
+    sh:order 1.0 ;
+    sh:datatype xsd:string ;
+  ] ;
 .
 
 object:Architecture
@@ -366,31 +366,31 @@ object:Architecture
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:Architecture ;
   sh:property [
-      rdfs:label "Bouwstijl"@nl ;
-      sh:path dbpo:architecturalStyle ;
-      sh:maxCount 1 ;
-      sh:order 1.0 ;
-      dash:editor memorix:VocabularyEditor ;
-      sh:class skos:Concept ;
-      memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/3c90d4f9-bbd3-4c6a-a473-541b87d7a7af> ) ;
-      sh:nodeKind sh:IRI ;
-    ] ;
+    rdfs:label "Bouwstijl"@nl ;
+    sh:path dbpo:architecturalStyle ;
+    sh:maxCount 1 ;
+    sh:order 1.0 ;
+    dash:editor memorix:VocabularyEditor ;
+    sh:class skos:Concept ;
+    memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/3c90d4f9-bbd3-4c6a-a473-541b87d7a7af> ) ;
+    sh:nodeKind sh:IRI ;
+  ] ;
   sh:property [
-      rdfs:label "Zuiverheid"@nl ;
-      sh:path rico:certainty ;
-      sh:maxCount 1 ;
-      sh:order 1.5 ;
-      sh:datatype xsd:string ;
-      dash:singleLine true ;
-    ] ;
+    rdfs:label "Zuiverheid"@nl ;
+    sh:path rico:certainty ;
+    sh:maxCount 1 ;
+    sh:order 1.5 ;
+    sh:datatype xsd:string ;
+    dash:singleLine true ;
+  ] ;
   sh:property [
-      rdfs:label "Bouwstijl betreft/opmerking"@nl ;
-      sh:path rico:descriptiveNote ;
-      sh:maxCount 1 ;
-      sh:order 0.5 ;
-      sh:datatype xsd:string ;
-      dash:editor  dash:TextAreaEditor ;
-    ] ;
+    rdfs:label "Bouwstijl betreft/opmerking"@nl ;
+    sh:path rico:descriptiveNote ;
+    sh:maxCount 1 ;
+    sh:order 0.5 ;
+    sh:datatype xsd:string ;
+    dash:editor  dash:TextAreaEditor ;
+  ] ;
 .
 object:BagAddress
   a sh:NodeShape ;
@@ -398,24 +398,24 @@ object:BagAddress
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:BagAddress ;
   sh:property [
-      rdfs:label "Toestand"@nl ;
-      sh:path bag:status ;
-      sh:maxCount 1 ;
-      sh:order 3.0 ;
-      dash:editor memorix:VocabularyEditor ;
-      sh:class skos:Concept ;
-      memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/da1d9451-8a91-4c83-b15a-04c8105e0ad7> ) ;
-      sh:nodeKind sh:IRI ;
-    ] ;
+    rdfs:label "Toestand"@nl ;
+    sh:path bag:status ;
+    sh:maxCount 1 ;
+    sh:order 3.0 ;
+    dash:editor memorix:VocabularyEditor ;
+    sh:class skos:Concept ;
+    memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/da1d9451-8a91-4c83-b15a-04c8105e0ad7> ) ;
+    sh:nodeKind sh:IRI ;
+  ] ;
   sh:property [
-      rdfs:label "Situering"@nl ;
-      sh:path rico:location ;
-      sh:maxCount 1 ;
-      sh:order 2.0 ;
-      memorix:inSummaryAt 2.0 ;
-      sh:datatype xsd:string ;
-      dash:singleLine true ;
-    ] ;
+    rdfs:label "Situering"@nl ;
+    sh:path rico:location ;
+    sh:maxCount 1 ;
+    sh:order 2.0 ;
+    memorix:inSummaryAt 2.0 ;
+    sh:datatype xsd:string ;
+    dash:singleLine true ;
+  ] ;
   sh:property [
     rdfs:label "BAG adres"@nl ;
     sh:path bag:identifier ;
@@ -435,34 +435,34 @@ object:BgtTopography
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:BgtTopography ;
   sh:property [
-      rdfs:label "Toestand"@nl ;
-      sh:path rico:hasRecordState ;
-      sh:maxCount 1 ;
-      sh:order 3.0 ;
-      dash:editor memorix:VocabularyEditor ;
-      sh:class skos:Concept ;
-      memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/da1d9451-8a91-4c83-b15a-04c8105e0ad7> ) ;
-      sh:nodeKind sh:IRI ;
-    ] ;
+    rdfs:label "Toestand"@nl ;
+    sh:path rico:hasRecordState ;
+    sh:maxCount 1 ;
+    sh:order 3.0 ;
+    dash:editor memorix:VocabularyEditor ;
+    sh:class skos:Concept ;
+    memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/da1d9451-8a91-4c83-b15a-04c8105e0ad7> ) ;
+    sh:nodeKind sh:IRI ;
+  ] ;
   sh:property [
-      rdfs:label "Situering"@nl ;
-      # Zelfde sh:path als ↓ ??
-      sh:path rico:location ;
-      sh:maxCount 1 ;
-      sh:order 2.0 ;
-      sh:datatype xsd:string ;
-      dash:singleLine true ;
-    ] ;
+    rdfs:label "Situering"@nl ;
+    # Zelfde sh:path als ↓ ??
+    sh:path rico:location ;
+    sh:maxCount 1 ;
+    sh:order 2.0 ;
+    sh:datatype xsd:string ;
+    dash:singleLine true ;
+  ] ;
   sh:property [
-      rdfs:label "BGT adres"@nl ;
-      # Zelfde sh:path als ↑ ??
-      sh:path rico:location ;
-      sh:order 1.0 ;
-      sh:datatype xsd:string ;
-      dash:editor dash:TextFieldEditor ;
-      memorix:searchWeight 1.0 ;
-      # TODO dit moet een link naar BAG worden
-    ]
+    rdfs:label "BGT adres"@nl ;
+    # Zelfde sh:path als ↑ ??
+    sh:path rico:location ;
+    sh:order 1.0 ;
+    sh:datatype xsd:string ;
+    dash:editor dash:TextFieldEditor ;
+    memorix:searchWeight 1.0 ;
+    # TODO dit moet een link naar BAG worden
+  ]
 .
 object:DicoData
   a sh:NodeShape ;
@@ -470,40 +470,40 @@ object:DicoData
   sh:ignoredProperties ( rdf:type ) ;
   sh:targetClass object:DicoData ;
   sh:property [
-      rdfs:label "Geometrie data"@nl ;
-      sh:path geo:hasGeometry ;
-      sh:maxCount 1 ;
-      sh:order 1.0 ;
-      # TODO: geometriedata opnemen als Well-Known-Text data
-      sh:datatype geo:asWKT ;
-      dash:editor  dash:TextAreaEditor ;
-    ] ;
+    rdfs:label "Geometrie data"@nl ;
+    sh:path geo:asWKT ;
+    sh:maxCount 1 ;
+    sh:order 1.0 ;
+    # TODO: geometriedata opnemen als Well-Known-Text data
+    sh:datatype geo:wktLiteral ;
+    dash:editor  dash:TextAreaEditor ;
+  ] ;
   sh:property [
-      rdfs:label "Geometrie vorm"@nl ;
-      # TODO: Wat is hier het doel van?
-      sh:path dbpo:shape ;
-      sh:maxCount 1 ;
-      sh:order 2.0 ;
-      dash:editor memorix:VocabularyEditor ;
-      sh:class skos:Concept ;
-      memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/817164bb-03bb-3b68-8327-416558a8455c> ) ;
-      sh:nodeKind sh:IRI ;
-    ] ;
+    rdfs:label "Geometrie vorm"@nl ;
+    # TODO: Wat is hier het doel van?
+    sh:path dbpo:shape ;
+    sh:maxCount 1 ;
+    sh:order 2.0 ;
+    dash:editor memorix:VocabularyEditor ;
+    sh:class skos:Concept ;
+    memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/817164bb-03bb-3b68-8327-416558a8455c> ) ;
+    sh:nodeKind sh:IRI ;
+  ] ;
 .
 
 object:basicDataGroup a sh:PropertyGroup ;
-    rdfs:label "Basis gegevens"@nl ;
-    sh:order 1.0
+  rdfs:label "Basis gegevens"@nl ;
+  sh:order 1.0
 .
 object:procedureDataGroup a sh:PropertyGroup ;
-    rdfs:label "Procedure gegevens"@nl ;
-    sh:order 2.0
+  rdfs:label "Procedure gegevens"@nl ;
+  sh:order 2.0
 .
 object:valueDataGroup a sh:PropertyGroup ;
-    rdfs:label "Waarde gegevens"@nl ;
-    sh:order 3.0
+  rdfs:label "Waarde gegevens"@nl ;
+  sh:order 3.0
 .
 object:locationGroup a sh:PropertyGroup ;
-    rdfs:label "Locatie"@nl ;
-    sh:order 4.0
+  rdfs:label "Locatie"@nl ;
+  sh:order 4.0
 .

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -108,6 +108,7 @@ recordtypes:Persoonsvermelding
         sh:maxCount  20 ;
         sh:order     3.7 ;
         # Niet helemaal duidelijk wat voor "titel" hier wordt bedoeld.
+        # Is dit een koninklijke titel, een aanspreektitel of -vorm?
         sh:path      foaf:title
     ] ;
 
@@ -137,7 +138,7 @@ recordtypes:Persoonsvermelding
         sh:datatype        xsd:string ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           2.6 ;
-        sh:path            persoonsvermelding:surnamePrefix
+        sh:path            dbpo:prefix
     ] ;
     sh:property              [
         rdfs:label   "Leeftijd"@nl ;
@@ -293,18 +294,19 @@ persoonsvermelding:Details
         sh:path      brt:Wijk
     ] ;
     sh:property           [
+        # Typo??? Wijk huisnummer -> Wijknummer?
         rdfs:label   "Wijk huisnummer"@nl ;
         sh:maxCount  1 ;
         sh:datatype  xsd:integer ;
         sh:order     7.0 ;
-        sh:path      persoonsvermelding:locationDistrictNumber
+        sh:path      dbpo:district
     ] ;
     sh:property           [
         rdfs:label   "Wijk toevoeging"@nl ;
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     8.0 ;
-        sh:path      persoonsvermelding:locationDistrictNumberAddition
+        sh:path      dbpo:district
     ] ;
     sh:property           [
         rdfs:label   "Gebuurte"@nl ;

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -1,4 +1,4 @@
-@prefix bag:                <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix bag:                <http://bag.basisregistraties.overheid.nl/def/bag#> .
 @prefix brt:                <http://brt.basisregistraties.overheid.nl/def/top10nl#> .
 @prefix dash:               <http://datashapes.org/dash#> .
 @prefix dbpo:               <http://dbpedia.org/ontology/> .

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -27,7 +27,7 @@ recordtypes:Persoonsvermelding
         sh:order     0.2 ;
         sh:maxCount 10 ;
         memorix:inTitleAt  0.5 ;
-        sh:path      persoonsvermelding:role ;
+        sh:path      schema:roleName ;
         dash:editor memorix:VocabularyEditor ;
         sh:class skos:Concept ;
         memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/7b9df6df-1c81-463f-85e1-d8ce7d002ab7> ) ;

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -1,9 +1,12 @@
 @prefix bag:                <https://bag.basisregistraties.overheid.nl/datamodel#> .
+@prefix brt:                <http://brt.basisregistraties.overheid.nl/def/top10nl#> .
 @prefix dash:               <http://datashapes.org/dash#> .
+@prefix dbpo:               <http://dbpedia.org/ontology/> .
 @prefix dc:                 <http://purl.org/dc/terms/> .
 @prefix foaf:               <http://xmlns.com/foaf/0.1/> .
 @prefix html:               <http://www.w3.org/1999/xhtml/> .
 @prefix memorix:            <http://memorix.io/ontology#> .
+@prefix person:             <http://www.w3.org/ns/person#> .
 @prefix persoonsvermelding: </resources/recordtypes/Persoonsvermelding#> .
 @prefix rdf:                <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:               <http://www.w3.org/2000/01/rdf-schema#> .
@@ -42,7 +45,7 @@ recordtypes:Persoonsvermelding
         sh:datatype        xsd:string ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           1.0 ;
-        sh:path            persoonsvermelding:firstName
+        sh:path            schema:givenName
     ] ;
     sh:property              [
         rdfs:label         "Achternaam"@nl ;
@@ -51,7 +54,7 @@ recordtypes:Persoonsvermelding
         sh:datatype        xsd:string ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           3.0 ;
-        sh:path            persoonsvermelding:lastName
+        sh:path            schema:familyName
     ] ;
     sh:property              [
         rdfs:label   "Opmerkingen openbaar"@nl ;
@@ -60,7 +63,7 @@ recordtypes:Persoonsvermelding
         sh:group     persoonsvermelding:remarksGroup ;
         sh:maxCount  1 ;
         sh:order     1.0 ;
-        sh:path      persoonsvermelding:publicNotes
+        sh:path      rico:descriptiveNote
     ] ;
     sh:property              [
         rdfs:comment  "Bijzonderheid bij deze akte"@nl ;
@@ -71,7 +74,7 @@ recordtypes:Persoonsvermelding
         sh:maxCount   10 ;
         sh:nodeKind   sh:BlankNode ;
         sh:order      1.0 ;
-        sh:path       persoonsvermelding:details
+        sh:path       rico:descriptiveNote
     ] ;
     sh:property              [
         rdfs:label         "Achtervoegsel"@nl ;
@@ -79,15 +82,16 @@ recordtypes:Persoonsvermelding
         sh:maxCount  1 ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           3.3 ;
-        sh:path            persoonsvermelding:suffix
+        sh:path            schema:honorificSuffix
     ] ;
     sh:property              [
+        # Wat is het verschil met sh:property [ rdfs:label "Leeftijd"@nl ... ] ???
         rdfs:label   "Leeftijd (jaar)"@nl ;
         sh:datatype  xsd:integer ;
         sh:maxCount  1 ;
         sh:group     persoonsvermelding:personListingGroup ;
         sh:order     8.5 ;
-        sh:path      persoonsvermelding:ageYear
+        sh:path      foaf:age
     ] ;
     sh:property              [
         rdfs:label   "Religie"@nl ;
@@ -95,7 +99,7 @@ recordtypes:Persoonsvermelding
         sh:datatype  xsd:string ;
         sh:group     persoonsvermelding:personListingGroup ;
         sh:order     9.0 ;
-        sh:path      persoonsvermelding:religion
+        sh:path      dbpo:religion
     ] ;
     sh:property              [
         rdfs:label   "Titel"@nl ;
@@ -103,7 +107,8 @@ recordtypes:Persoonsvermelding
         sh:group     persoonsvermelding:personListingGroup ;
         sh:maxCount  20 ;
         sh:order     3.7 ;
-        sh:path      persoonsvermelding:title
+        # Niet helemaal duidelijk wat voor "titel" hier wordt bedoeld.
+        sh:path      foaf:title
     ] ;
 
     sh:property              [
@@ -123,7 +128,7 @@ recordtypes:Persoonsvermelding
         sh:group     persoonsvermelding:remarksGroup ;
         sh:maxCount  1 ;
         sh:order     2.0 ;
-        sh:path      persoonsvermelding:internalNotes
+        sh:path      rico:descriptiveNote
     ] ;
     sh:property              [
         rdfs:label         "Tussenvoegsel"@nl ;
@@ -140,15 +145,15 @@ recordtypes:Persoonsvermelding
         sh:maxCount  1 ;
         sh:group     persoonsvermelding:personListingGroup ;
         sh:order     8.0 ;
-        sh:path      persoonsvermelding:age
+        sh:path      foaf:age
     ] ;
     sh:property              [
         rdfs:label          "Geslacht"@nl ;
-        sh:maxCount  1 ;
+        sh:maxCount         1 ;
         sh:group            persoonsvermelding:personListingGroup ;
         sh:order            3.6 ;
-        sh:path             persoonsvermelding:gender ;
-        dash:editor memorix:VocabularyEditor ;
+        sh:path             schema:gender ;
+        dash:editor         memorix:VocabularyEditor ;
         sh:class skos:Concept ;
         memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/bf92f5f7-d8be-45b8-be59-c79af171ce11> ) ;
         sh:nodeKind sh:IRI ;
@@ -159,7 +164,7 @@ recordtypes:Persoonsvermelding
         sh:datatype        xsd:string ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           0.5 ;
-        sh:path            persoonsvermelding:prefix
+        sh:path            dbpo:prefix
     ] ;
     sh:property              [
         rdfs:comment  "Locaties die voorkomen op de akte"@nl ;
@@ -170,7 +175,7 @@ recordtypes:Persoonsvermelding
         sh:maxCount   999 ;
         sh:nodeKind   sh:BlankNode ;
         sh:order      1.0 ;
-        sh:path       persoonsvermelding:location
+        sh:path       schema:contentLocation
     ] ;
     sh:property              [
         rdfs:comment  "Beroepen die voorkomen op de akte"@nl ;
@@ -181,7 +186,7 @@ recordtypes:Persoonsvermelding
         sh:maxCount   999 ;
         sh:nodeKind   sh:BlankNode ;
         sh:order      10.0 ;
-        sh:path       persoonsvermelding:profession
+        sh:path       schema:hasOccupation
     ] ;
     sh:property              [
         rdfs:label         "Patroniem"@nl ;
@@ -190,7 +195,7 @@ recordtypes:Persoonsvermelding
         sh:datatype        xsd:string ;
         sh:group           persoonsvermelding:personListingGroup ;
         sh:order           2.5 ;
-        sh:path            persoonsvermelding:patronymic
+        sh:path            person:patronymicName
     ] ;
     sh:targetClass           recordtypes:Persoonsvermelding .
 
@@ -221,7 +226,7 @@ persoonsvermelding:Details
     sh:ignoredProperties  ( rdf:type ) ;
     sh:property           [ rdfs:label          "Bijzonderheid - Type"@nl ;
     sh:order            1.0 ;
-    sh:path             persoonsvermelding:detailType ;
+    sh:path             rico:hasContentOfType ;
     sh:maxCount  1 ;
     dash:editor memorix:VocabularyEditor ;
     sh:class skos:Concept ;
@@ -233,7 +238,7 @@ persoonsvermelding:Details
     sh:datatype  xsd:string ;
     sh:maxCount  1 ;
     sh:order     2.0 ;
-    sh:path      persoonsvermelding:detailDetail
+    sh:path      rico:descriptiveNote
     ] ;
     sh:targetClass        persoonsvermelding:Details .
 
@@ -245,7 +250,7 @@ persoonsvermelding:Details
         rdfs:label          "Locatie - Type"@nl ;
         sh:maxCount         1 ;
         sh:order            1.0 ;
-        sh:path             persoonsvermelding:locationType ;
+        sh:path             rico:hasOrHadPlaceType ;
         dash:editor memorix:VocabularyEditor ;
         sh:class skos:Concept ;
         memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/42cfec07-894f-4e72-a80d-1418f5ecc324> ) ;
@@ -270,7 +275,7 @@ persoonsvermelding:Details
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     4.0 ;
-        sh:path      persoonsvermelding:locationHousenumberAddition
+        sh:path      bag:huisnummertoevoeging
     ] ;
     sh:property           [
         rdfs:label   "Plaats"@nl ;
@@ -284,7 +289,8 @@ persoonsvermelding:Details
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     6.0 ;
-        sh:path      persoonsvermelding:locationDistrict
+        # Eigenlijk een klasse, maar veruit de beste match
+        sh:path      brt:Wijk
     ] ;
     sh:property           [
         rdfs:label   "Wijk huisnummer"@nl ;
@@ -305,35 +311,37 @@ persoonsvermelding:Details
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     9.0 ;
-        sh:path      persoonsvermelding:locationNeighborhood
+        # Eigenlijk een klasse, maar veruit de beste match
+        sh:path      brt:Buurtschap
     ] ;
     sh:property           [
-        rdfs:label   "Bon"@nl ;
+        # Typo??? "Bon" ??? -> "Bron"
+        rdfs:label   "Bron"@nl ;
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     10.0 ;
-        sh:path      persoonsvermelding:locationSource
+        sh:path      dc:source
     ] ;
     sh:property           [
         rdfs:label   "Huisnaam"@nl ;
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     11.0 ;
-        sh:path      persoonsvermelding:locationHouseName
+        sh:path      dbpo:house
     ] ;
     sh:property           [
         rdfs:label   "Werkveld locatie"@nl ;
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     12.0 ;
-        sh:path      persoonsvermelding:locationLocation
+        sh:path      schema:workLocation
     ] ;
     sh:property           [
         rdfs:label   "Locatie - Uri"@nl ;
         sh:datatype  xsd:string ;
         sh:maxCount  10 ;
         sh:order     14.0 ;
-        sh:path      persoonsvermelding:locationUri
+        sh:path      rico:hasOrHadLocation
     ] ;
     sh:property           [
         rdfs:label   "Opmerking"@nl ;
@@ -341,7 +349,7 @@ persoonsvermelding:Details
         dash:editor  dash:TextAreaEditor ;
         sh:datatype  xsd:string ;
         sh:order     15.0 ;
-        sh:path      persoonsvermelding:locationRemark
+        sh:path      rico:descriptiveNote
     ] ;
     sh:targetClass        persoonsvermelding:Location .
 
@@ -354,13 +362,13 @@ persoonsvermelding:Profession
         sh:maxCount  1 ;
         sh:datatype  xsd:string ;
         sh:order     1.0 ;
-        sh:path      persoonsvermelding:professionProfession
+        sh:path      rico:hasOrHadOccupationOfType
     ] ;
     sh:property              [
         rdfs:label          "Gestandaardiseerd beroep"@nl ;
         sh:maxCount  1 ;
         sh:order            2.0 ;
-        sh:path             persoonsvermelding:professionStandardizedProfession ;
+        sh:path             rico:hasOrHadOccupationOfType ;
         dash:editor memorix:VocabularyEditor ;
         sh:class skos:Concept ;
         memorix:conceptSchemeIn ( </resources/vocabularies/conceptschemes/44f97a78-f417-4a89-a368-9882a5bf7c84> ) ;
@@ -390,6 +398,6 @@ persoonsvermelding:Event  rdf:type          sh:NodeShape ;
         sh:datatype  xsd:integer ;
         sh:maxCount  1 ;
         sh:order     3.0 ;
-        sh:path      persoonsvermelding:hasDate
+        sh:path      dc:date
     ] ;
     sh:targetClass        persoonsvermelding:Event .

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -1,3 +1,4 @@
+@prefix bag:                <https://bag.basisregistraties.overheid.nl/datamodel#> .
 @prefix dash:               <http://datashapes.org/dash#> .
 @prefix dc:                 <http://purl.org/dc/terms/> .
 @prefix foaf:               <http://xmlns.com/foaf/0.1/> .
@@ -262,7 +263,7 @@ persoonsvermelding:Details
         sh:maxCount  1 ;
         sh:datatype  xsd:integer ;
         sh:order     3.0 ;
-        sh:path      persoonsvermelding:locationHousenumber
+        sh:path      bag:huisnummer
     ] ;
     sh:property           [
         rdfs:label   "Toevoeging"@nl ;

--- a/shacl/Persoonsvermelding.ttl
+++ b/shacl/Persoonsvermelding.ttl
@@ -1,17 +1,18 @@
 @prefix dash:               <http://datashapes.org/dash#> .
 @prefix dc:                 <http://purl.org/dc/terms/> .
+@prefix foaf:               <http://xmlns.com/foaf/0.1/> .
 @prefix html:               <http://www.w3.org/1999/xhtml/> .
-@prefix persoonsvermelding: </resources/recordtypes/Persoonsvermelding#> .
 @prefix memorix:            <http://memorix.io/ontology#> .
+@prefix persoonsvermelding: </resources/recordtypes/Persoonsvermelding#> .
 @prefix rdf:                <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:               <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix rico:               <https://www.ica.org/standards/RiC/ontology#> .
 @prefix recordtypes:        </resources/recordtypes/> .
+@prefix rico:               <https://www.ica.org/standards/RiC/ontology#> .
+@prefix schema:             <http://schema.org/> .
 @prefix sh:                 <http://www.w3.org/ns/shacl#> .
 @prefix skos:               <http://www.w3.org/2004/02/skos/core#> .
 @prefix vocabularies:       </resources/vocabularies/> .
 @prefix xsd:                <http://www.w3.org/2001/XMLSchema#> .
-@prefix schema:             <http://schema.org/> .
 
 recordtypes:Persoonsvermelding
     rdf:type                 memorix:Recordtype , sh:NodeShape ;

--- a/validate.py
+++ b/validate.py
@@ -5,6 +5,7 @@ import os
 import re
 from argparse import ArgumentParser
 from tempfile import TemporaryDirectory
+from xml.sax import SAXParseException
 
 import pyshacl
 import rdflib
@@ -142,8 +143,9 @@ def load_graph_from_uri(resolvable_part: str) -> rdflib.Graph:
 
         try:
             resolved_uri_graph.parse(tempfile)
-        except rdflib.plugin.PluginException:
-            logging.error(f'Error loading {resolvable_part}')
+        except SAXParseException:
+            with open(tempfile, 'rt') as f:
+                logging.error(f'Error loading {resolvable_part}: invalid XML \n {f.read()}')
             raise
 
         return resolved_uri_graph

--- a/voorbeelddata/bestanddeel.ttl
+++ b/voorbeelddata/bestanddeel.ttl
@@ -79,7 +79,7 @@
                                        ] ;
         bestanddeel:relatedActor       [ rdf:type                bestanddeel:RelatedActor ;
                                          bestanddeel:actorActor  <https://lei-migrate.memorix.io/resources/records/042c7c87-1d5f-36ca-98aa-bd22c4244ab7> ;
-                                         bestanddeel:actorRole   <https://lei-migrate.memorix.io/resources/vocabularies/concepts/c946779c-5364-4d52-942c-fada8310f049>
+                                         schema:roleName <https://lei-migrate.memorix.io/resources/vocabularies/concepts/c946779c-5364-4d52-942c-fada8310f049>
                                        ] ;
         bestanddeel:status             <https://lei-migrate.memorix.io/resources/vocabularies/concepts/155d5402-73ab-4e6d-b7d3-74ffda7b1b6a> ;
         rico:identifier                "91" ;


### PR DESCRIPTION
- Consistent gebruik van schema:roleName voor alle properties met label "Rol", zelfs als dat redelijk passende  rico:creationWithRole mapping heeft: dit maakt dat je _alle_ mensen met een bepaalde rol via een _enkele property_ kan terugvinden
- Consistent gebruik van bag:huisnummer voor huisnummers